### PR TITLE
libstagefright: Add more sample rates for FLAC

### DIFF
--- a/media/libstagefright/FLACExtractor.cpp
+++ b/media/libstagefright/FLACExtractor.cpp
@@ -585,6 +585,8 @@ status_t FLACParser::init()
         case 48000:
         case 88200:
         case 96000:
+        case 176400:
+        case 192000:
             break;
         default:
             ALOGE("unsupported sample rate %u", getSampleRate());


### PR DESCRIPTION
* Fix for example:
  E/FLACExtractor(  636): unsupported sample rate 192000

* Based on
  https://github.com/LineageOS/android_frameworks_av/commit/b2c7134f634b8798b22b5ebe03b0b258b1d7196d
  https://github.com/google/ExoPlayer/commit/0b0868889ec3caaa64579d0f3212229fc987a304

Change-Id: I338ddff8f866c3646651243df0b31099e81ab56c